### PR TITLE
fix: prevent React.Children.only crash in Button asChild mode

### DIFF
--- a/src/core/shared-utils/ui/button.tsx
+++ b/src/core/shared-utils/ui/button.tsx
@@ -57,8 +57,14 @@ function Button({
       aria-busy={loading}
       {...props}
     >
-      {loading && !asChild && <Loader2 className="animate-spin" aria-hidden="true" />}
-      {children}
+      {asChild
+        ? children
+        : (
+          <>
+            {loading && <Loader2 className="animate-spin" aria-hidden="true" />}
+            {children}
+          </>
+        )}
     </Comp>
   );
 }


### PR DESCRIPTION
## Summary
- Blog post pages crash with `React.Children.only expected to receive a single React element child`
- When `asChild=true`, the `<Slot>` component received `[false, children]` — two children instead of one
- Fixed by conditionally rendering: `asChild` passes only `children` to Slot; non-asChild wraps loader + children in a fragment

## Test plan
- [ ] Visit `https://spike.land/blog/spike-land-launch` — should render without crash
- [ ] Visit `https://spike.land/blog` — index should still work
- [ ] Check browser console — no `React.Children.only` error
- [ ] Buttons with `loading` prop still show spinner correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)