### PR TITLE
🧪 Add tests for deleteGalleryImage in client.ts

### DIFF
--- a/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
+++ b/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { deleteGalleryImage } from "../client";
+
+describe("client", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("deleteGalleryImage", () => {
+    it("should call fetch with the correct path and options", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await deleteGalleryImage("test-image-id");
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/gallery/image/test-image-id", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer demo",
+        },
+      });
+    });
+
+    it("should include gemini key and image model in headers if present in storage", async () => {
+      vi.spyOn(sessionStorage, "getItem").mockImplementation((key) => {
+        if (key === "gemini_api_key") return "test-gemini-key";
+        return null;
+      });
+      vi.spyOn(localStorage, "getItem").mockImplementation((key) => {
+        if (key === "pref_image_model") return "test-image-model";
+        return null;
+      });
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await deleteGalleryImage("test-image-id");
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/gallery/image/test-image-id", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer demo",
+          "X-Gemini-Key": "test-gemini-key",
+          "X-Image-Model": "test-image-model",
+        },
+      });
+    });
+
+    it("should throw an error if the response is not ok", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("Not Found"),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(deleteGalleryImage("test-image-id")).rejects.toThrow("API error 404: Not Found");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added tests for `deleteGalleryImage` in `packages/image-studio-worker/frontend/src/api/client.ts`. Previously, this client API function lacked unit test coverage.

📊 **Coverage:** What scenarios are now tested
*   Verification that `fetch` is called with the correct URL path (`/api/gallery/image/${imageId}`) and the `{ method: 'DELETE' }` option.
*   Verification that the appropriate base headers (e.g., `Authorization`) are automatically added by the underlying `apiFetch`.
*   Verification that additional headers (`X-Gemini-Key` and `X-Image-Model`) are included if present in `sessionStorage` and `localStorage`.
*   Verification that the function correctly rejects and throws an error when the API response is not OK (e.g., a 404 response).

✨ **Result:** The improvement in test coverage
Increased test coverage for the frontend API client. `deleteGalleryImage` is now fully tested, ensuring safe refactoring in the future.

---
*PR created automatically by Jules for task [13696042775677542276](https://jules.google.com/task/13696042775677542276) started by @zerdos*