### PR TITLE
🧪 Add tests for eventBus

### DIFF
--- a/packages/image-studio-worker/frontend/src/services/__tests__/event-bus.test.ts
+++ b/packages/image-studio-worker/frontend/src/services/__tests__/event-bus.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eventBus } from "../event-bus";
+
+describe("eventBus", () => {
+  beforeEach(() => {
+    eventBus.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("should successfully instantiate and expose methods", () => {
+    expect(eventBus).toBeDefined();
+    expect(typeof eventBus.on).toBe("function");
+    expect(typeof eventBus.emit).toBe("function");
+    expect(typeof eventBus.off).toBe("function");
+    expect(typeof eventBus.clear).toBe("function");
+  });
+
+  it("should allow subscribing and emitting events", () => {
+    const handler = vi.fn();
+    eventBus.on("album:created", handler);
+
+    eventBus.emit("album:created", { albumId: "123", name: "Vacation" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ albumId: "123", name: "Vacation" });
+  });
+
+  it("should allow unsubscribing from events using off()", () => {
+    const handler = vi.fn();
+    eventBus.on("image:deleted", handler);
+    eventBus.off("image:deleted", handler);
+
+    eventBus.emit("image:deleted", { imageId: "abc" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should allow unsubscribing from events using the returned function", () => {
+    const handler = vi.fn();
+    const unsubscribe = eventBus.on("gallery:updated", handler);
+
+    unsubscribe();
+
+    eventBus.emit("gallery:updated", { reason: "refresh" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should execute multiple handlers for the same event", () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    eventBus.on("image:uploaded", handler1);
+    eventBus.on("image:uploaded", handler2);
+
+    eventBus.emit("image:uploaded", { imageId: "img1", url: "http://example.com/img1.jpg", name: "img1.jpg" });
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not crash if a handler throws an error, and should execute subsequent handlers", () => {
+    const failingHandler = vi.fn(() => {
+      throw new Error("Handler failed");
+    });
+    const successfulHandler = vi.fn();
+
+    // Mock console.error to avoid test output noise
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    eventBus.on("image:generated", failingHandler);
+    eventBus.on("image:generated", successfulHandler);
+
+    expect(() => {
+      eventBus.emit("image:generated", { imageId: "gen1", url: "http://example.com/gen1.jpg", prompt: "A dog" });
+    }).not.toThrow();
+
+    expect(failingHandler).toHaveBeenCalledTimes(1);
+    expect(successfulHandler).toHaveBeenCalledTimes(1);
+
+    // Verify console.error was called with the correct message and error object
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[EventBus] Error in handler for image:generated:",
+      expect.any(Error)
+    );
+  });
+
+  it("should clear all handlers when clear() is called", () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    eventBus.on("album:updated", handler1);
+    eventBus.on("chat:image-attached", handler2);
+
+    eventBus.clear();
+
+    eventBus.emit("album:updated", { albumId: "1" });
+    eventBus.emit("chat:image-attached", { file: new File([""], "test.png") });
+
+    expect(handler1).not.toHaveBeenCalled();
+    expect(handler2).not.toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4635,6 +4635,9 @@ __metadata:
     playwright: "npm:^1.58.2"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
+    react-markdown: "npm:^10.1.0"
+    rehype-raw: "npm:^7.0.0"
+    remark-gfm: "npm:^4.0.1"
     tailwind-merge: "npm:^3.5.0"
     tailwindcss: "npm:^4.2.1"
     tsx: "npm:^4.21.0"
@@ -4763,6 +4766,16 @@ __metadata:
     vitest: "npm:4.0.18"
   bin:
     state-machine-cli: ./dist/cli.js
+  languageName: unknown
+  linkType: soft
+
+"@spike-land-ai/status@workspace:packages/status":
+  version: 0.0.0-use.local
+  resolution: "@spike-land-ai/status@workspace:packages/status"
+  dependencies:
+    "@cloudflare/workers-types": "npm:4.20260307.1"
+    typescript: "npm:5.9.3"
+    wrangler: "npm:4.71.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a comprehensive test suite for the singleton `eventBus` service used in the `image-studio-worker` frontend.

📊 **Coverage:** What scenarios are now tested
The new Vitest test cases verify:
- Successful instantiation and method exposure.
- Subscribing to events (`on`) and emitting events (`emit`).
- Removing listeners via `off()` and the unsubscription callback returned by `on()`.
- Allowing multiple listeners for the same event and firing them properly.
- Error handling isolation (ensuring a failing handler does not crash the bus or block subsequent handlers).
- Clearing all registered listeners (`clear()`).

✨ **Result:** The improvement in test coverage
The `event-bus.ts` module is now fully covered with unit tests, ensuring future changes to the event pub-sub logic won't introduce regressions.

---
*PR created automatically by Jules for task [14124592997215520435](https://jules.google.com/task/14124592997215520435) started by @zerdos*