### PR TITLE
🔒 Fix XSS vulnerability in documentation rendering

### DIFF
--- a/src/frontend/platform-frontend/ui/routes/docs/$slug.tsx
+++ b/src/frontend/platform-frontend/ui/routes/docs/$slug.tsx
@@ -1,7 +1,7 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { apiUrl } from "../../../core-logic/api";
 import { useEffect, useState } from "react";
-import { sanitizeUrl, escapeHtml } from "../../../core-logic/lib/security";
+import { sanitizeUrl } from "../../../core-logic/lib/security";
 
 const SITE_URL = "https://spike.land";
 
@@ -107,18 +107,45 @@ export function DocPage() {
         );
       if (line.startsWith("---")) return <hr key={i} className="my-8 border-border" />;
       if (line.trim() === "") return <br key={i} />;
-      // Handle links in markdown [text](url)
-      const withLinks = line.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => {
+
+      // Handle links in markdown [text](url) safely by splitting the string into an array of React elements
+      const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+      const parts: (string | JSX.Element)[] = [];
+      let lastIndex = 0;
+      let match;
+
+      while ((match = linkRegex.exec(line)) !== null) {
+        if (match.index > lastIndex) {
+          parts.push(line.substring(lastIndex, match.index));
+        }
+
+        const text = match[1];
+        const url = match[2];
         const safeUrl = sanitizeUrl(url);
-        const safeText = escapeHtml(text);
-        return `<a href="${safeUrl}" class="text-primary underline hover:text-primary/80" target="_blank" rel="noopener noreferrer">${safeText}</a>`;
-      });
+
+        parts.push(
+          <a
+            key={`${i}-${match.index}`}
+            href={safeUrl}
+            className="text-primary underline hover:text-primary/80"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {text}
+          </a>,
+        );
+
+        lastIndex = linkRegex.lastIndex;
+      }
+
+      if (lastIndex < line.length) {
+        parts.push(line.substring(lastIndex));
+      }
+
       return (
-        <p
-          key={i}
-          className="text-foreground leading-relaxed mb-2"
-          dangerouslySetInnerHTML={{ __html: withLinks }}
-        />
+        <p key={i} className="text-foreground leading-relaxed mb-2">
+          {parts.length > 0 ? parts : line}
+        </p>
       );
     });
   };


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability in the documentation page (`src/frontend/platform-frontend/ui/routes/docs/$slug.tsx`) caused by rendering untrusted markdown content using `dangerouslySetInnerHTML`.
⚠️ **Risk:** If a malicious user or compromised backend supplied documentation containing raw HTML tags (like `<script>`), those tags would be directly executed in the browser context, leading to potential data exfiltration or session hijacking.
🛡️ **Solution:** Removed the `dangerouslySetInnerHTML` attribute. The `renderContent` logic was refactored to parse text strings using regex and dynamically construct an array of literal strings and React `<a>` components. React automatically escapes literal strings, perfectly mitigating the XSS threat while preserving the intended link parsing behavior. Tested locally using Playwright to confirm script tags render safely as text.

---
*PR created automatically by Jules for task [16856654579154891332](https://jules.google.com/task/16856654579154891332) started by @zerdos*