### PR TITLE
test: add parseToolResult tests to client test suite

### DIFF
--- a/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
+++ b/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { deleteGalleryImage } from "../client";
+import { deleteGalleryImage, parseToolResult } from "../client";
+import type { ToolResult } from "../client";
 
 describe("client", () => {
   beforeEach(() => {
@@ -69,6 +70,54 @@ describe("client", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       await expect(deleteGalleryImage("test-image-id")).rejects.toThrow("API error 404: Not Found");
+    });
+  });
+
+  describe("parseToolResult", () => {
+    it("parses valid JSON result correctly", () => {
+      const validJsonResult: ToolResult = {
+        content: [{ type: "text", text: '{"key": "value", "num": 42}' }],
+        isError: false,
+      };
+
+      const parsed = parseToolResult<{ key: string; num: number }>(validJsonResult);
+      expect(parsed).toEqual({ key: "value", num: 42 });
+    });
+
+    it("throws an error if isError is true", () => {
+      const errorResult: ToolResult = {
+        content: [{ type: "text", text: "Something went wrong" }],
+        isError: true,
+      };
+
+      expect(() => parseToolResult(errorResult)).toThrowError("Something went wrong");
+    });
+
+    it("throws a default error if isError is true but no text is provided", () => {
+      const errorResult: ToolResult = {
+        content: [],
+        isError: true,
+      };
+
+      expect(() => parseToolResult(errorResult)).toThrowError("Unknown error");
+    });
+
+    it("throws an error if content is empty (and isError is false)", () => {
+      const emptyResult: ToolResult = {
+        content: [],
+        isError: false,
+      };
+
+      expect(() => parseToolResult(emptyResult)).toThrowError("Empty result");
+    });
+
+    it("throws an error if text is not valid JSON", () => {
+      const invalidJsonResult: ToolResult = {
+        content: [{ type: "text", text: "not json" }],
+        isError: false,
+      };
+
+      expect(() => parseToolResult(invalidJsonResult)).toThrowError(SyntaxError);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds 5 unit tests for `parseToolResult` covering valid JSON, error handling, empty content, and invalid JSON
- Merges into existing `client.test.ts` alongside `deleteGalleryImage` tests

Supersedes #32 (which conflicted with #23).

## Test plan
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)