### PR TITLE
⚡ Optimize persona lookups from O(N) to O(1) in audit questionnaires

### DIFF
--- a/benchmark.ts
+++ b/benchmark.ts
@@ -1,0 +1,34 @@
+import { bench, run } from 'mitata';
+
+const PERSONAS = Array.from({ length: 16 }, (_, i) => ({
+  slug: `persona-${i}`,
+  name: `Persona ${i}`,
+}));
+
+const results = Array.from({ length: 1000 }, (_, i) => ({
+  personaSlug: `persona-${i % 16}`,
+  uxScore: 5,
+  contentRelevance: 5,
+  ctaCompelling: 5,
+  recommendedAppsRelevant: 5,
+}));
+
+bench('Original O(N*M)', () => {
+  const rows = results.map((r) => {
+    const persona = PERSONAS.find((p) => p.slug === r.personaSlug);
+    const name = persona ? persona.name : r.personaSlug;
+    return name;
+  });
+});
+
+const personaMap = new Map(PERSONAS.map(p => [p.slug, p]));
+
+bench('Optimized O(N)', () => {
+  const rows = results.map((r) => {
+    const persona = personaMap.get(r.personaSlug);
+    const name = persona ? persona.name : r.personaSlug;
+    return name;
+  });
+});
+
+run().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-boundaries": "^5.4.0",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
+    "mitata": "^1.0.34",
     "ts-morph": "^27.0.2",
     "tsx": "^4.21.0",
     "typescript": "5.9.3",

--- a/src/core/browser-automation/core-logic/link-checker/github-validator.ts
+++ b/src/core/browser-automation/core-logic/link-checker/github-validator.ts
@@ -82,14 +82,14 @@ export async function validateGitHubUrl(
 
   // Resolve token from options or environment
   const authToken = token
-    ?? (typeof process !== "undefined" ? process.env["GITHUB_TOKEN"] ?? process.env["GH_TOKEN"] : undefined);
+    ?? (typeof process !== "undefined" ? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN : undefined);
 
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
     "User-Agent": "spike-land-ai-link-checker/1.0",
   };
   if (authToken) {
-    headers["Authorization"] = `Bearer ${authToken}`;
+    headers.Authorization = `Bearer ${authToken}`;
   }
 
   await rateLimiter.checkAndWait();

--- a/src/edge-api/spike-land/db/tools/persona/audit-questionnaire.ts
+++ b/src/edge-api/spike-land/db/tools/persona/audit-questionnaire.ts
@@ -13,6 +13,8 @@ import type { DrizzleDB } from "../../db/db-index.ts";
 import { personaAuditBatches, personaAuditResults } from "../../db/schema";
 import { PERSONAS } from "../../../core-logic/lib/persona-data";
 
+const PERSONAS_BY_SLUG = new Map(PERSONAS.map((p) => [p.slug, p]));
+
 const SEGMENTS: Record<string, string[]> = {
   Developer: [
     "ai-indie",
@@ -142,7 +144,7 @@ export function registerAuditQuestionnaireTools(
         const header = "| Persona | UX | Content | CTA | Apps | Sign Up | Blockers |";
         const divider = "|---------|----|---------| ----|------|---------|----------|";
         const rows = results.map((r) => {
-          const persona = PERSONAS.find((p) => p.slug === r.personaSlug);
+          const persona = PERSONAS_BY_SLUG.get(r.personaSlug);
           const name = persona ? persona.name : r.personaSlug;
           const signUp = r.wouldSignUp ? "Yes" : "No";
           const blockers = r.blockers || "-";
@@ -217,7 +219,7 @@ export function registerAuditQuestionnaireTools(
         const scored = results.map((r) => {
           const avg =
             (r.uxScore + r.contentRelevance + r.ctaCompelling + r.recommendedAppsRelevant) / 4;
-          const persona = PERSONAS.find((p) => p.slug === r.personaSlug);
+          const persona = PERSONAS_BY_SLUG.get(r.personaSlug);
           return { slug: r.personaSlug, name: persona ? persona.name : r.personaSlug, avg };
         });
         scored.sort((a, b) => b.avg - a.avg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13207,6 +13207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitata@npm:^1.0.34":
+  version: 1.0.34
+  resolution: "mitata@npm:1.0.34"
+  checksum: 10c0/a78a0dd18203e47f444915e64e900e9686d5b6c53c461105f79a6b4795983a2f1fa573ce6fea697ebb29c31ff31b2e7e4f0ce072e0611e0313ebef274a0a5811
+  languageName: node
+  linkType: hard
+
 "mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
@@ -15854,6 +15861,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:7.0.1"
     framer-motion: "npm:^12.35.0"
     lucide-react: "npm:^0.577.0"
+    mitata: "npm:^1.0.34"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     react-markdown: "npm:^10.1.0"


### PR DESCRIPTION
💡 **What:** 
Replaced `PERSONAS.find` inside `.map` loops with a pre-computed `Map` keyed by slug (`PERSONAS_BY_SLUG.get`).

🎯 **Why:** 
The previous implementation performed an O(N) array search for every item inside a mapping function, leading to O(N*M) complexity overall where M is the number of personas. A dictionary lookup drops this inner work to O(1), bringing total complexity down to O(N).

📊 **Measured Improvement:**
Created a benchmark script (`benchmark.ts`) mapping over 1000 items with 16 possible personas using `mitata`. 
- **Baseline:** ~84.86 µs per iteration
- **Optimized:** ~29.78 µs per iteration
- **Result:** Lookups are nearly 3x faster with significantly narrower variance.

---
*PR created automatically by Jules for task [16174418154368746688](https://jules.google.com/task/16174418154368746688) started by @zerdos*