### PR TITLE
🧪 Add tests for uploadToGallery in client.ts

### DIFF
--- a/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
+++ b/packages/image-studio-worker/frontend/src/api/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { deleteGalleryImage } from "../client";
+import { deleteGalleryImage, uploadToGallery } from "../client";
 
 describe("client", () => {
   beforeEach(() => {
@@ -10,6 +10,91 @@ describe("client", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  describe("uploadToGallery", () => {
+    it("should upload a file correctly without optional parameters", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ image: { id: "test-id" }, url: "test-url" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const file = new File(["test-content"], "test.png", { type: "image/png" });
+      const result = await uploadToGallery(file);
+
+      expect(result).toEqual({ image: { id: "test-id" }, url: "test-url" });
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[0]).toBe("/api/gallery/upload");
+      expect(callArgs[1].method).toBe("POST");
+      expect(callArgs[1].headers).toEqual({
+        Authorization: "Bearer demo",
+      });
+
+      const body = callArgs[1].body as FormData;
+      expect(body).toBeInstanceOf(FormData);
+      expect(body.get("file")).toBe(file);
+      expect(body.has("name")).toBe(false);
+      expect(body.has("tags")).toBe(false);
+      expect(body.has("albumId")).toBe(false);
+    });
+
+    it("should append optional parameters correctly to FormData", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ image: { id: "test-id" }, url: "test-url" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const file = new File(["test-content"], "test.png", { type: "image/png" });
+      await uploadToGallery(file, {
+        name: "Test Name",
+        tags: ["tag1", "tag2"],
+        albumId: "album-123",
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = callArgs[1].body as FormData;
+      expect(body.get("file")).toBe(file);
+      expect(body.get("name")).toBe("Test Name");
+      expect(body.get("tags")).toBe(JSON.stringify(["tag1", "tag2"]));
+      expect(body.get("albumId")).toBe("album-123");
+    });
+
+    it("should include gemini key in headers if present in storage", async () => {
+      vi.spyOn(sessionStorage, "getItem").mockImplementation((key) => {
+        if (key === "gemini_api_key") return "test-gemini-key";
+        return null;
+      });
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const file = new File(["test-content"], "test.png", { type: "image/png" });
+      await uploadToGallery(file);
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers).toEqual({
+        Authorization: "Bearer demo",
+        "X-Gemini-Key": "test-gemini-key",
+      });
+    });
+
+    it("should throw an error if the upload fails", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Bad Request"),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const file = new File(["test-content"], "test.png", { type: "image/png" });
+      await expect(uploadToGallery(file)).rejects.toThrow("Upload failed 400: Bad Request");
+    });
   });
 
   describe("deleteGalleryImage", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap in `uploadToGallery` function in `client.ts` is addressed.
📊 **Coverage:** Scenarios tested include basic file upload, file upload with optional parameters verifying FormData serialization, ensuring `sessionStorage` is accessed correctly for `gemini_api_key`, and testing that an error is thrown if the upload fails.
✨ **Result:** Test coverage for `uploadToGallery` is significantly improved.

---
*PR created automatically by Jules for task [16312053740000718501](https://jules.google.com/task/16312053740000718501) started by @zerdos*