### PR TITLE
⚡ [Performance] Replace sync file read with async in monaco deploy script

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+const ITERATIONS = 10000;
+const TEST_FILE = path.join(__dirname, "test_cache.txt");
+
+async function runBenchmark() {
+  // Setup
+  fs.writeFileSync(TEST_FILE, "a1b2c3d4e5f6g7h8");
+
+  // Benchmark Sync
+  const startSync = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    if (fs.existsSync(TEST_FILE)) {
+      const content = fs.readFileSync(TEST_FILE, "utf-8").trim();
+    }
+  }
+  const endSync = performance.now();
+  const syncTime = endSync - startSync;
+
+  // Benchmark Async
+  const startAsync = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    try {
+      const content = await fs.promises.readFile(TEST_FILE, "utf-8");
+      content.trim();
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw e;
+      }
+    }
+  }
+  const endAsync = performance.now();
+  const asyncTime = endAsync - startAsync;
+
+  console.log(`Sync time: ${syncTime.toFixed(2)}ms`);
+  console.log(`Async time: ${asyncTime.toFixed(2)}ms`);
+
+  // Cleanup
+  fs.unlinkSync(TEST_FILE);
+}
+
+runBenchmark().catch(console.error);

--- a/scripts/deploy-monaco.ts
+++ b/scripts/deploy-monaco.ts
@@ -89,8 +89,12 @@ async function main() {
   console.log(`Generated monaco-editor bundle hash: ${finalHash}`);
 
   let oldHash = "";
-  if (fs.existsSync(CACHE_FILE)) {
-    oldHash = fs.readFileSync(CACHE_FILE, "utf-8").trim();
+  try {
+    oldHash = (await fs.promises.readFile(CACHE_FILE, "utf-8")).trim();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
   }
 
   const R2_BUCKET = "spike-app-assets";


### PR DESCRIPTION
💡 **What:** 
Replaced the synchronous `fs.existsSync` and `fs.readFileSync` calls with `await fs.promises.readFile` enclosed in a `try/catch` block handling the `ENOENT` error in `scripts/deploy-monaco.ts`.

🎯 **Why:** 
The issue identified that like other sync IO in build scripts, `fs.readFileSync` reads a cache file sequentially, blocking the event loop. Transitioning to `fs.promises.readFile` ensures that file system operations do not block the thread and uses more idiomatic asynchronous programming. It also eliminates the Time-Of-Check to Time-Of-Use (TOCTOU) race condition inherent to calling `existsSync` prior to reading a file.

📊 **Measured Improvement:** 
I established a performance baseline by writing a micro-benchmark (`scripts/benchmark.ts` included in the PR) to test the synchronous vs asynchronous file reads over 10,000 iterations for a small file similar to the cache file.

*   **Synchronous benchmark baseline:** ~116.62ms
*   **Asynchronous benchmark result:** ~4525.20ms

**Rationale:** While the benchmark demonstrates that a tight loop of sequential synchronous file reads of an extremely small file is faster in absolute wall-clock time in Node.js compared to the promise overhead of the async version, the actual performance impact on overall build time is negligible (as noted in the issue description). The primary benefit of this change is architectural: it prevents the event loop from being blocked by synchronous I/O, allowing other concurrent tasks (if any were added in the future) to execute while waiting for disk operations, aligning the code with best practices for Node.js build scripts.

---
*PR created automatically by Jules for task [7600927285544000162](https://jules.google.com/task/7600927285544000162) started by @zerdos*