### PR TITLE
🔒 Fix command injection in Docker Compose service registry

### DIFF
--- a/src/mcp-tools/docker-compose/core-logic/service-registry.ts
+++ b/src/mcp-tools/docker-compose/core-logic/service-registry.ts
@@ -88,13 +88,13 @@ export class ServiceRegistry {
     const args = ["compose"];
     switch (action) {
       case "up":
-        args.push("up", "-d", service);
+        args.push("up", "-d", "--", service);
         break;
       case "stop":
-        args.push("stop", service);
+        args.push("stop", "--", service);
         break;
       case "restart":
-        args.push("restart", service);
+        args.push("restart", "--", service);
         break;
     }
 
@@ -115,7 +115,7 @@ export class ServiceRegistry {
     if (since) {
       args.push("--since", since);
     }
-    args.push(service);
+    args.push("--", service);
 
     const { stdout } = await execFileAsync("docker", args, {
       cwd: process.env.COMPOSE_PROJECT_DIR ?? "/app",

--- a/test-docker/docker-compose.yml
+++ b/test-docker/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  myservice:
+    image: alpine
+    command: echo hello


### PR DESCRIPTION
🎯 What: Added the `--` POSIX delimiter to `docker compose` commands before appending the user-supplied `service` argument in `ServiceRegistry.execCompose` and `ServiceRegistry.getLogs`.
⚠️ Risk: If a malicious user supplies an argument starting with a hyphen (`-`) or constructs arguments in an unexpected way, they could inject arbitrary flags/arguments to the `docker compose` command, potentially causing unexpected behavior or even commanding Docker to perform unintended actions (e.g., executing arbitrary entrypoints).
🛡️ Solution: Inserting the double hyphen `--` parameter before positional arguments indicates the end of command options, meaning everything following it is treated as a positional argument, thus completely neutralizing options/argument injection.

---
*PR created automatically by Jules for task [11518332232948310111](https://jules.google.com/task/11518332232948310111) started by @zerdos*