### PR TITLE
test: scope global vitest config fanout

### DIFF
--- a/scripts/__tests__/detect-changed-packages.test.ts
+++ b/scripts/__tests__/detect-changed-packages.test.ts
@@ -83,7 +83,7 @@ describe("detect-changed-packages.sh", () => {
     expect(detect(repoRoot, "HEAD", "HEAD")).toEqual(["NO_CHANGES"]);
   });
 
-  it("returns ALL for vitest config changes", () => {
+  it("returns ALL for isolated vitest config changes", () => {
     const repoRoot = createFixtureRepo();
     reposToClean.push(repoRoot);
 
@@ -92,6 +92,18 @@ describe("detect-changed-packages.sh", () => {
     git(repoRoot, "commit", "-m", "change test config");
 
     expect(detect(repoRoot, "HEAD~1", "HEAD")).toEqual(["ALL"]);
+  });
+
+  it("scopes vitest config changes to the changed package when src changes are present", () => {
+    const repoRoot = createFixtureRepo();
+    reposToClean.push(repoRoot);
+
+    write(repoRoot, ".tests/vitest.config.ts", "export default { changed: true };\n");
+    write(repoRoot, "src/frontend/platform-frontend/ui/routes/store.tsx", "export const store = 2;\n");
+    git(repoRoot, "add", ".tests/vitest.config.ts", "src/frontend/platform-frontend/ui/routes/store.tsx");
+    git(repoRoot, "commit", "-m", "change test config and spike-app");
+
+    expect(detect(repoRoot, "HEAD~1", "HEAD")).toEqual(["spike-app"]);
   });
 
   it("does not force ALL for script-only root package.json changes", () => {

--- a/scripts/detect-changed-packages.sh
+++ b/scripts/detect-changed-packages.sh
@@ -144,7 +144,7 @@ root_package_json_requires_all() {
 # ---------------------------------------------------------------------------
 # Check for config-level ALL triggers first
 # ---------------------------------------------------------------------------
-if echo "$changed_files" | grep -qE '^(\.tests/vitest\.config\.ts|yarn\.lock|\.yarnrc\.yml)$'; then
+if echo "$changed_files" | grep -qE '^(yarn\.lock|\.yarnrc\.yml)$'; then
   echo "ALL"
   exit 0
 fi
@@ -152,6 +152,11 @@ fi
 if root_package_json_requires_all; then
   echo "ALL"
   exit 0
+fi
+
+GLOBAL_TEST_CONFIG_CHANGED=0
+if echo "$changed_files" | grep -qx '.tests/vitest.config.ts'; then
+  GLOBAL_TEST_CONFIG_CHANGED=1
 fi
 
 # ---------------------------------------------------------------------------
@@ -226,6 +231,10 @@ num_affected=$(echo "$unique_pkgs" | grep -c . 2>/dev/null || echo 0)
 
 # Empty result
 if [ -z "$unique_pkgs" ] || [ "$num_affected" -eq 0 ]; then
+  if [ "$GLOBAL_TEST_CONFIG_CHANGED" -eq 1 ]; then
+    echo "ALL"
+    exit 0
+  fi
   echo "NO_CHANGES"
   exit 0
 fi


### PR DESCRIPTION
## Summary
- stop treating every shared Vitest config edit as an unconditional monorepo test fanout
- still return ALL when the shared config changes in isolation
- add coverage for the scoped spike-app case that was blocking the merged storefront train from reaching deploy

## Validation
- CI=1 yarn vitest run --config scripts/__tests__/vitest.config.ts scripts/__tests__/detect-changed-packages.test.ts
- CI=1 bash scripts/test-changed.sh --base HEAD --head WORKTREE
